### PR TITLE
Fixed unwanted has-error class on non-related validation

### DIFF
--- a/src/RadioButtonList/widget/AssocRadioButtonList.js
+++ b/src/RadioButtonList/widget/AssocRadioButtonList.js
@@ -207,8 +207,8 @@ define([
                 console.debug(this.id + "._addValidation");
                 if (message) {
                     this._showError(message);
-                }
-                dojoClass.add(this.radioButtonContainer, "has-error");
+                    dojoClass.add(this.radioButtonContainer, "has-error");
+                }                
             },
 
             _resetSubscriptions: function () {


### PR DESCRIPTION
If any validation occurs on the context entity, the _addValidation function adds class has-error to the radioButtonContainer. Changed to only add if there's actually a validation message for the radio button list.